### PR TITLE
popper js imported

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -11,6 +11,7 @@
 // about supported directives.
 //
 //= require jquery
+//= require popper
 //= require bootstrap-sprockets
 //= require jquery_ujs
 //= require turbolinks


### PR DESCRIPTION
# WHAT 
popper jsがbootstrap4beta以降で必須になったため、jsにrequireした。